### PR TITLE
Add aria-current to active navigation links

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -28,7 +28,7 @@
           <a href="index.html#services">Services</a>
           <a href="index.html#about">About</a>
           <a href="index.html#how">Process</a>
-          <a href="blog.html" class="active">Blog</a>
+          <a href="blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <!-- Main navigation header -->
     <header class="main-header">
       <div class="container nav-container">
-        <a href="index.html" class="logo">AIAGENTSAGE</a>
+        <a href="index.html" class="logo" aria-current="page">AIAGENTSAGE</a>
         <nav class="main-nav">
           <a href="index.html#services">Services</a>
           <a href="index.html#about">About</a>

--- a/posts/5-ways-automation-reduces-operational-costs.html
+++ b/posts/5-ways-automation-reduces-operational-costs.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/ai-dashboards-why-you-need-one-and-what-it-should-track.html
+++ b/posts/ai-dashboards-why-you-need-one-and-what-it-should-track.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/ai-in-2025-what-every-business-owner-should-be-preparing-for.html
+++ b/posts/ai-in-2025-what-every-business-owner-should-be-preparing-for.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/ai-zapier-building-smart-automations-without-code.html
+++ b/posts/ai-zapier-building-smart-automations-without-code.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/automated-workflows-that-improve-team-productivity.html
+++ b/posts/automated-workflows-that-improve-team-productivity.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/automation-for-business-growth.html
+++ b/posts/automation-for-business-growth.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/automation-for-e-commerce-reduce-refunds-and-boost-conversions.html
+++ b/posts/automation-for-e-commerce-reduce-refunds-and-boost-conversions.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/automation-in-real-estate-from-lead-capture-to-property-scheduling.html
+++ b/posts/automation-in-real-estate-from-lead-capture-to-property-scheduling.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/best-tools-to-automate-your-business-in-2025.html
+++ b/posts/best-tools-to-automate-your-business-in-2025.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/from-chaos-to-clarity-how-ai-brought-structure-to-our-growth.html
+++ b/posts/from-chaos-to-clarity-how-ai-brought-structure-to-our-growth.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/from-startup-to-scalable-the-role-of-automation-in-business-evolution.html
+++ b/posts/from-startup-to-scalable-the-role-of-automation-in-business-evolution.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/how-agencies-use-ai-to-deliver-results-at-scale.html
+++ b/posts/how-agencies-use-ai-to-deliver-results-at-scale.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/how-ai-agents-help-startups-scale-faster.html
+++ b/posts/how-ai-agents-help-startups-scale-faster.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/how-ai-helps-businesses-do-more-with-less-staff.html
+++ b/posts/how-ai-helps-businesses-do-more-with-less-staff.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/how-ai-is-transforming-healthcare-admin-and-patient-coordination.html
+++ b/posts/how-ai-is-transforming-healthcare-admin-and-patient-coordination.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/how-automation-helped-us-reclaim-30-plus-hours-a-week.html
+++ b/posts/how-automation-helped-us-reclaim-30-plus-hours-a-week.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/how-to-build-an-automation-strategy-for-your-business.html
+++ b/posts/how-to-build-an-automation-strategy-for-your-business.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/how-to-choose-the-right-automation-tools-for-your-business.html
+++ b/posts/how-to-choose-the-right-automation-tools-for-your-business.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/how-to-integrate-slack-google-and-crms-using-ai-agents.html
+++ b/posts/how-to-integrate-slack-google-and-crms-using-ai-agents.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/how-to-use-ai-to-eliminate-repetitive-admin-work.html
+++ b/posts/how-to-use-ai-to-eliminate-repetitive-admin-work.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/lessons-from-automating-our-own-business-operations.html
+++ b/posts/lessons-from-automating-our-own-business-operations.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/logistics-and-delivery-ai-use-cases-that-save-time-and-fuel.html
+++ b/posts/logistics-and-delivery-ai-use-cases-that-save-time-and-fuel.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/rpa-vs-ai-agents-whats-the-difference-and-when-to-use-each.html
+++ b/posts/rpa-vs-ai-agents-whats-the-difference-and-when-to-use-each.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/the-first-5-processes-every-founder-should-automate.html
+++ b/posts/the-first-5-processes-every-founder-should-automate.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/the-future-of-business-intelligence-ai-powered-decision-making.html
+++ b/posts/the-future-of-business-intelligence-ai-powered-decision-making.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/the-hidden-costs-of-manual-processes-and-how-to-fix-them.html
+++ b/posts/the-hidden-costs-of-manual-processes-and-how-to-fix-them.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/the-roi-of-ai-how-businesses-save-time-and-money-with-automation.html
+++ b/posts/the-roi-of-ai-how-businesses-save-time-and-money-with-automation.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/top-10-business-tasks-you-can-automate-today.html
+++ b/posts/top-10-business-tasks-you-can-automate-today.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/what-is-an-ai-agent-a-beginner-friendly-breakdown.html
+++ b/posts/what-is-an-ai-agent-a-beginner-friendly-breakdown.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/why-process-automation-is-the-key-to-lean-business-growth.html
+++ b/posts/why-process-automation-is-the-key-to-lean-business-growth.html
@@ -25,7 +25,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"

--- a/posts/why-we-started-aiagentsage-and-what-we-learned-about-ai.html
+++ b/posts/why-we-started-aiagentsage-and-what-we-learned-about-ai.html
@@ -26,7 +26,7 @@
           <a href="../index.html#services">Services</a>
           <a href="../index.html#about">About</a>
           <a href="../index.html#how">Process</a>
-          <a href="../blog.html" class="active">Blog</a>
+          <a href="../blog.html" class="active" aria-current="page">Blog</a>
           <a
             href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq"
             class="btn btn-primary nav-cta"


### PR DESCRIPTION
## Summary
- set aria-current on the home logo link for the index page
- mark the Blog nav link as current in blog index and all post pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e1420f9083339d96620a20a53ca4