### PR TITLE
Add privacy and terms pages and update footer links

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -492,8 +492,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="privacy.html">Privacy Policy</a>
+          <a href="terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -264,8 +264,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="privacy.html">Privacy Policy</a>
+          <a href="terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/5-ways-automation-reduces-operational-costs.html
+++ b/posts/5-ways-automation-reduces-operational-costs.html
@@ -129,8 +129,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/ai-dashboards-why-you-need-one-and-what-it-should-track.html
+++ b/posts/ai-dashboards-why-you-need-one-and-what-it-should-track.html
@@ -135,8 +135,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/ai-in-2025-what-every-business-owner-should-be-preparing-for.html
+++ b/posts/ai-in-2025-what-every-business-owner-should-be-preparing-for.html
@@ -136,8 +136,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/ai-zapier-building-smart-automations-without-code.html
+++ b/posts/ai-zapier-building-smart-automations-without-code.html
@@ -134,8 +134,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/automated-workflows-that-improve-team-productivity.html
+++ b/posts/automated-workflows-that-improve-team-productivity.html
@@ -129,8 +129,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/automation-for-business-growth.html
+++ b/posts/automation-for-business-growth.html
@@ -129,8 +129,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/automation-for-e-commerce-reduce-refunds-and-boost-conversions.html
+++ b/posts/automation-for-e-commerce-reduce-refunds-and-boost-conversions.html
@@ -134,8 +134,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/automation-in-real-estate-from-lead-capture-to-property-scheduling.html
+++ b/posts/automation-in-real-estate-from-lead-capture-to-property-scheduling.html
@@ -133,8 +133,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/best-tools-to-automate-your-business-in-2025.html
+++ b/posts/best-tools-to-automate-your-business-in-2025.html
@@ -135,8 +135,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/from-chaos-to-clarity-how-ai-brought-structure-to-our-growth.html
+++ b/posts/from-chaos-to-clarity-how-ai-brought-structure-to-our-growth.html
@@ -130,8 +130,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/from-startup-to-scalable-the-role-of-automation-in-business-evolution.html
+++ b/posts/from-startup-to-scalable-the-role-of-automation-in-business-evolution.html
@@ -133,8 +133,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/how-agencies-use-ai-to-deliver-results-at-scale.html
+++ b/posts/how-agencies-use-ai-to-deliver-results-at-scale.html
@@ -131,8 +131,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/how-ai-agents-help-startups-scale-faster.html
+++ b/posts/how-ai-agents-help-startups-scale-faster.html
@@ -135,8 +135,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/how-ai-helps-businesses-do-more-with-less-staff.html
+++ b/posts/how-ai-helps-businesses-do-more-with-less-staff.html
@@ -127,8 +127,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/how-ai-is-transforming-healthcare-admin-and-patient-coordination.html
+++ b/posts/how-ai-is-transforming-healthcare-admin-and-patient-coordination.html
@@ -135,8 +135,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/how-automation-helped-us-reclaim-30-plus-hours-a-week.html
+++ b/posts/how-automation-helped-us-reclaim-30-plus-hours-a-week.html
@@ -137,8 +137,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/how-to-build-an-automation-strategy-for-your-business.html
+++ b/posts/how-to-build-an-automation-strategy-for-your-business.html
@@ -136,8 +136,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/how-to-choose-the-right-automation-tools-for-your-business.html
+++ b/posts/how-to-choose-the-right-automation-tools-for-your-business.html
@@ -134,8 +134,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/how-to-integrate-slack-google-and-crms-using-ai-agents.html
+++ b/posts/how-to-integrate-slack-google-and-crms-using-ai-agents.html
@@ -132,8 +132,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/how-to-use-ai-to-eliminate-repetitive-admin-work.html
+++ b/posts/how-to-use-ai-to-eliminate-repetitive-admin-work.html
@@ -131,8 +131,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/lessons-from-automating-our-own-business-operations.html
+++ b/posts/lessons-from-automating-our-own-business-operations.html
@@ -135,8 +135,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/logistics-and-delivery-ai-use-cases-that-save-time-and-fuel.html
+++ b/posts/logistics-and-delivery-ai-use-cases-that-save-time-and-fuel.html
@@ -132,8 +132,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/rpa-vs-ai-agents-whats-the-difference-and-when-to-use-each.html
+++ b/posts/rpa-vs-ai-agents-whats-the-difference-and-when-to-use-each.html
@@ -139,8 +139,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/the-first-5-processes-every-founder-should-automate.html
+++ b/posts/the-first-5-processes-every-founder-should-automate.html
@@ -140,8 +140,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/the-future-of-business-intelligence-ai-powered-decision-making.html
+++ b/posts/the-future-of-business-intelligence-ai-powered-decision-making.html
@@ -134,8 +134,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/the-hidden-costs-of-manual-processes-and-how-to-fix-them.html
+++ b/posts/the-hidden-costs-of-manual-processes-and-how-to-fix-them.html
@@ -129,8 +129,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/the-roi-of-ai-how-businesses-save-time-and-money-with-automation.html
+++ b/posts/the-roi-of-ai-how-businesses-save-time-and-money-with-automation.html
@@ -134,8 +134,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/top-10-business-tasks-you-can-automate-today.html
+++ b/posts/top-10-business-tasks-you-can-automate-today.html
@@ -141,8 +141,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/what-is-an-ai-agent-a-beginner-friendly-breakdown.html
+++ b/posts/what-is-an-ai-agent-a-beginner-friendly-breakdown.html
@@ -136,8 +136,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/why-process-automation-is-the-key-to-lean-business-growth.html
+++ b/posts/why-process-automation-is-the-key-to-lean-business-growth.html
@@ -135,8 +135,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/posts/why-we-started-aiagentsage-and-what-we-learned-about-ai.html
+++ b/posts/why-we-started-aiagentsage-and-what-we-learned-about-ai.html
@@ -134,8 +134,8 @@
       <div class="container footer-bottom">
         <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
         <nav class="footer-legal">
-          <a href="#">Privacy Policy</a>
-          <a href="#">Terms of Service</a>
+          <a href="../privacy.html">Privacy Policy</a>
+          <a href="../terms.html">Terms of Service</a>
         </nav>
       </div>
     </footer>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy – AIAGENTSAGE</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-pc6evEzVtPTdHISqEX7lf9KYm9qCxem0rWeEdHrF2rrI8u3q1Xa3T1xkjWIfCd7vhlJYYjQx89gdud8z88r1eA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body>
+    <header class="main-header">
+      <div class="container nav-container">
+        <a href="index.html" class="logo">AIAGENTSAGE</a>
+        <nav class="main-nav">
+          <a href="index.html#services">Services</a>
+          <a href="index.html#about">About</a>
+          <a href="index.html#how">Process</a>
+          <a href="blog.html">Blog</a>
+          <a href="index.html#contact">Contact</a>
+        </nav>
+      </div>
+    </header>
+    <main class="section">
+      <div class="container">
+        <h1 class="section-title">Privacy Policy</h1>
+        <p>Your privacy matters to us. This page outlines how AIAGENTSAGE handles your information.</p>
+      </div>
+    </main>
+    <footer class="footer">
+      <div class="container footer-container">
+        <div class="footer-brand">
+          <span class="footer-logo">AIAGENTSAGE</span>
+          <p class="footer-tagline">Smarter Business, Powered by AI Agents.</p>
+        </div>
+        <nav class="footer-nav">
+          <a href="index.html#services">Services</a>
+          <a href="index.html#about">About</a>
+          <a href="index.html#how">Process</a>
+          <a href="blog.html">Blog</a>
+          <a href="index.html#contact">Contact</a>
+        </nav>
+        <div class="footer-social">
+          <a href="https://www.linkedin.com" aria-label="LinkedIn" target="_blank" rel="noopener"><i class="fab fa-linkedin-in"></i></a>
+          <a href="https://twitter.com" aria-label="Twitter" target="_blank" rel="noopener"><i class="fab fa-twitter"></i></a>
+          <a href="https://www.youtube.com" aria-label="YouTube" target="_blank" rel="noopener"><i class="fab fa-youtube"></i></a>
+        </div>
+      </div>
+      <div class="container footer-bottom">
+        <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
+        <nav class="footer-legal">
+          <a href="privacy.html">Privacy Policy</a>
+          <a href="terms.html">Terms of Service</a>
+        </nav>
+      </div>
+    </footer>
+    <script src="js/scripts.js"></script>
+  </body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Terms of Service – AIAGENTSAGE</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-pc6evEzVtPTdHISqEX7lf9KYm9qCxem0rWeEdHrF2rrI8u3q1Xa3T1xkjWIfCd7vhlJYYjQx89gdud8z88r1eA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body>
+    <header class="main-header">
+      <div class="container nav-container">
+        <a href="index.html" class="logo">AIAGENTSAGE</a>
+        <nav class="main-nav">
+          <a href="index.html#services">Services</a>
+          <a href="index.html#about">About</a>
+          <a href="index.html#how">Process</a>
+          <a href="blog.html">Blog</a>
+          <a href="index.html#contact">Contact</a>
+        </nav>
+      </div>
+    </header>
+    <main class="section">
+      <div class="container">
+        <h1 class="section-title">Terms of Service</h1>
+        <p>These terms govern the use of AIAGENTSAGE's services and website.</p>
+      </div>
+    </main>
+    <footer class="footer">
+      <div class="container footer-container">
+        <div class="footer-brand">
+          <span class="footer-logo">AIAGENTSAGE</span>
+          <p class="footer-tagline">Smarter Business, Powered by AI Agents.</p>
+        </div>
+        <nav class="footer-nav">
+          <a href="index.html#services">Services</a>
+          <a href="index.html#about">About</a>
+          <a href="index.html#how">Process</a>
+          <a href="blog.html">Blog</a>
+          <a href="index.html#contact">Contact</a>
+        </nav>
+        <div class="footer-social">
+          <a href="https://www.linkedin.com" aria-label="LinkedIn" target="_blank" rel="noopener"><i class="fab fa-linkedin-in"></i></a>
+          <a href="https://twitter.com" aria-label="Twitter" target="_blank" rel="noopener"><i class="fab fa-twitter"></i></a>
+          <a href="https://www.youtube.com" aria-label="YouTube" target="_blank" rel="noopener"><i class="fab fa-youtube"></i></a>
+        </div>
+      </div>
+      <div class="container footer-bottom">
+        <span>&copy; <span id="year"></span> AIAGENTSAGE. All rights reserved.</span>
+        <nav class="footer-legal">
+          <a href="privacy.html">Privacy Policy</a>
+          <a href="terms.html">Terms of Service</a>
+        </nav>
+      </div>
+    </footer>
+    <script src="js/scripts.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated `privacy.html` and `terms.html` pages
- link new legal pages from footer of landing page, blog, and all posts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e1415efc83338cde0fc83965aab1