### PR TITLE
feat: send contact form to backend

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,9 +188,8 @@
           <form
             id="contactForm"
             class="contact-form"
-            action="mailto:prasaath@aiagentsage.com"
+            action="/api/contact"
             method="post"
-            enctype="text/plain"
           >
             <div class="form-group">
               <label for="name">Name</label>
@@ -217,6 +216,7 @@
               ></textarea>
             </div>
             <button type="submit" class="btn btn-primary">Send Message</button>
+            <div id="formStatus" class="form-status" aria-live="polite"></div>
           </form>
         </div>
       </section>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -13,6 +13,48 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // Contact form submission handler
-  // No custom JavaScript is required for the contact form because it relies on
-  // the mailto action to open the user’s default email client.
+  const contactForm = document.getElementById('contactForm');
+  if (contactForm) {
+    contactForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      const statusEl = document.getElementById('formStatus');
+      if (statusEl) {
+        statusEl.textContent = 'Sending...';
+        statusEl.className = 'form-status';
+      }
+
+      const formData = {
+        name: contactForm.name.value,
+        email: contactForm.email.value,
+        message: contactForm.message.value,
+      };
+
+      try {
+        const response = await fetch(contactForm.action, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(formData),
+        });
+
+        if (response.ok) {
+          if (statusEl) {
+            statusEl.textContent = 'Message sent successfully!';
+            statusEl.classList.add('success');
+          }
+          contactForm.reset();
+        } else {
+          throw new Error('Network response was not ok');
+        }
+      } catch (error) {
+        if (statusEl) {
+          statusEl.textContent = 'There was an error sending your message.';
+          statusEl.classList.add('error');
+        }
+        console.error('Error submitting form:', error);
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- replace mailto form action with `/api/contact`
- submit contact form via fetch and show success/error status

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e1409e34833381f5afb1c9855abd