### PR TITLE
Add responsive media queries for mobile layouts

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -611,6 +611,14 @@ a {
 
 /* Responsive */
 @media (max-width: 768px) {
+  .section {
+    padding: 3rem 0;
+  }
+
+  .section-title {
+    font-size: 1.75rem;
+  }
+
   .hero-title {
     font-size: 2rem;
   }
@@ -641,9 +649,41 @@ a {
   .hero {
     height: 70vh;
   }
+  .section {
+    padding: 2rem 0;
+  }
+
+  .section-title {
+    font-size: 1.5rem;
+  }
+
+  .hero-title {
+    font-size: 1.75rem;
+  }
+
+  .hero-subtitle {
+    font-size: 0.95rem;
+  }
+
+  .hero-buttons {
+    flex-direction: column;
+  }
+
+  .hero-buttons .btn {
+    margin: 0.5rem 0;
+  }
+
   .services-grid,
   .steps-grid {
     grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .footer-container,
+  .footer-bottom {
+    flex-direction: column;
+    text-align: center;
+    gap: 1rem;
   }
 }
 
@@ -715,6 +755,20 @@ a {
 
 .blog-card-link:hover {
   color: #00c853;
+}
+
+@media (max-width: 768px) {
+  .blog-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .blog-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
 }
 
 /* Post Page */


### PR DESCRIPTION
## Summary
- tune section padding and typography for tablets and phones
- stack grids, hero buttons, and footer elements vertically on narrow screens
- adjust blog grid to single-column layout on phones

## Testing
- `node screenshot.js` *(after installing puppeteer and dependencies; generated screenshots at 768px and 480px)*

------
https://chatgpt.com/codex/tasks/task_e_6891f499d37083339ab282f96e202cb9