### PR TITLE
Center about section layout and balance spacing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -193,12 +193,16 @@ a {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 2rem;
+  max-width: 1000px;
+  margin: 0 auto;
 }
 
 .about-text {
   flex: 1 1 55%;
+  text-align: center;
+  margin: 0 auto;
 }
 
 .about-text p {
@@ -212,6 +216,8 @@ a {
   display: flex;
   align-items: center;
   justify-content: center;
+  margin: 0 auto;
+  text-align: center;
 }
 
 .about-icon {
@@ -630,10 +636,6 @@ a {
   .about-container {
     flex-direction: column;
     text-align: center;
-  }
-
-  .about-image {
-    margin-top: 1rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- center the About section content block with flexbox and width constraints
- balance spacing in `.about-text` and `.about-image` with centered alignment
- simplify mobile styles to keep the section centered across screen sizes

## Testing
- `npx stylelint css/styles.css` *(fails: No configuration provided)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f48efbb883338668b0fee4d7f3d8