### PR TITLE
Add 'Back to Blog' links to posts

### DIFF
--- a/posts/5-ways-automation-reduces-operational-costs.html
+++ b/posts/5-ways-automation-reduces-operational-costs.html
@@ -98,6 +98,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/ai-dashboards-why-you-need-one-and-what-it-should-track.html
+++ b/posts/ai-dashboards-why-you-need-one-and-what-it-should-track.html
@@ -103,6 +103,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/ai-in-2025-what-every-business-owner-should-be-preparing-for.html
+++ b/posts/ai-in-2025-what-every-business-owner-should-be-preparing-for.html
@@ -104,6 +104,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/ai-zapier-building-smart-automations-without-code.html
+++ b/posts/ai-zapier-building-smart-automations-without-code.html
@@ -102,6 +102,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/automated-workflows-that-improve-team-productivity.html
+++ b/posts/automated-workflows-that-improve-team-productivity.html
@@ -98,6 +98,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/automation-for-business-growth.html
+++ b/posts/automation-for-business-growth.html
@@ -98,6 +98,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/automation-for-e-commerce-reduce-refunds-and-boost-conversions.html
+++ b/posts/automation-for-e-commerce-reduce-refunds-and-boost-conversions.html
@@ -102,6 +102,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/automation-in-real-estate-from-lead-capture-to-property-scheduling.html
+++ b/posts/automation-in-real-estate-from-lead-capture-to-property-scheduling.html
@@ -101,6 +101,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/best-tools-to-automate-your-business-in-2025.html
+++ b/posts/best-tools-to-automate-your-business-in-2025.html
@@ -103,6 +103,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/from-chaos-to-clarity-how-ai-brought-structure-to-our-growth.html
+++ b/posts/from-chaos-to-clarity-how-ai-brought-structure-to-our-growth.html
@@ -98,6 +98,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/from-startup-to-scalable-the-role-of-automation-in-business-evolution.html
+++ b/posts/from-startup-to-scalable-the-role-of-automation-in-business-evolution.html
@@ -102,6 +102,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/how-agencies-use-ai-to-deliver-results-at-scale.html
+++ b/posts/how-agencies-use-ai-to-deliver-results-at-scale.html
@@ -99,6 +99,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/how-ai-agents-help-startups-scale-faster.html
+++ b/posts/how-ai-agents-help-startups-scale-faster.html
@@ -104,6 +104,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/how-ai-helps-businesses-do-more-with-less-staff.html
+++ b/posts/how-ai-helps-businesses-do-more-with-less-staff.html
@@ -96,6 +96,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/how-ai-is-transforming-healthcare-admin-and-patient-coordination.html
+++ b/posts/how-ai-is-transforming-healthcare-admin-and-patient-coordination.html
@@ -103,6 +103,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/how-automation-helped-us-reclaim-30-plus-hours-a-week.html
+++ b/posts/how-automation-helped-us-reclaim-30-plus-hours-a-week.html
@@ -106,6 +106,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/how-to-build-an-automation-strategy-for-your-business.html
+++ b/posts/how-to-build-an-automation-strategy-for-your-business.html
@@ -104,6 +104,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/how-to-choose-the-right-automation-tools-for-your-business.html
+++ b/posts/how-to-choose-the-right-automation-tools-for-your-business.html
@@ -102,6 +102,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/how-to-integrate-slack-google-and-crms-using-ai-agents.html
+++ b/posts/how-to-integrate-slack-google-and-crms-using-ai-agents.html
@@ -100,6 +100,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/how-to-use-ai-to-eliminate-repetitive-admin-work.html
+++ b/posts/how-to-use-ai-to-eliminate-repetitive-admin-work.html
@@ -100,6 +100,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/lessons-from-automating-our-own-business-operations.html
+++ b/posts/lessons-from-automating-our-own-business-operations.html
@@ -103,6 +103,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/logistics-and-delivery-ai-use-cases-that-save-time-and-fuel.html
+++ b/posts/logistics-and-delivery-ai-use-cases-that-save-time-and-fuel.html
@@ -100,6 +100,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/rpa-vs-ai-agents-whats-the-difference-and-when-to-use-each.html
+++ b/posts/rpa-vs-ai-agents-whats-the-difference-and-when-to-use-each.html
@@ -107,6 +107,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/the-first-5-processes-every-founder-should-automate.html
+++ b/posts/the-first-5-processes-every-founder-should-automate.html
@@ -108,6 +108,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/the-future-of-business-intelligence-ai-powered-decision-making.html
+++ b/posts/the-future-of-business-intelligence-ai-powered-decision-making.html
@@ -102,6 +102,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/the-hidden-costs-of-manual-processes-and-how-to-fix-them.html
+++ b/posts/the-hidden-costs-of-manual-processes-and-how-to-fix-them.html
@@ -98,6 +98,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/the-roi-of-ai-how-businesses-save-time-and-money-with-automation.html
+++ b/posts/the-roi-of-ai-how-businesses-save-time-and-money-with-automation.html
@@ -103,6 +103,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/top-10-business-tasks-you-can-automate-today.html
+++ b/posts/top-10-business-tasks-you-can-automate-today.html
@@ -109,6 +109,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/what-is-an-ai-agent-a-beginner-friendly-breakdown.html
+++ b/posts/what-is-an-ai-agent-a-beginner-friendly-breakdown.html
@@ -104,6 +104,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/why-process-automation-is-the-key-to-lean-business-growth.html
+++ b/posts/why-process-automation-is-the-key-to-lean-business-growth.html
@@ -104,6 +104,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>

--- a/posts/why-we-started-aiagentsage-and-what-we-learned-about-ai.html
+++ b/posts/why-we-started-aiagentsage-and-what-we-learned-about-ai.html
@@ -102,6 +102,7 @@
           <div class="post-cta">
             <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0kivXExe_ll3ffea6R1m8SJdRfai1tmbapuNDReNpHVOjvNBvEL3FszsRr_HYiHwz7TZ3-sMjq" class="btn btn-primary" target="_blank" rel="noopener">Book a free strategy call</a>
           </div>
+          <a href="../blog.html" class="btn btn-secondary">Back to Blog</a>
 </div>
       </article>
     </main>


### PR DESCRIPTION
## Summary
- add a back-to-blog button to every article in `posts/`
- use existing secondary button styling for consistent look and feel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f48c23448333ba2134684f169750