### PR TITLE
Make blog cards fully clickable

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -78,7 +78,7 @@
             <img src="images/automation-growth.png" alt="Top 10 Business Tasks You Can Automate Today" />
             <div class="blog-card-content">
               <div class="blog-card-category">Automation for Business Growth</div>
-              <h3 class="blog-card-title">Top 10 Business Tasks You Can Automate Today</h3>
+              <a href="posts/top-10-business-tasks-you-can-automate-today.html" class="blog-card-title">Top 10 Business Tasks You Can Automate Today</a>
               <p class="blog-card-excerpt">
                 Discover the most time‑consuming tasks that are ripe for automation – from data
                 entry and invoice processing to customer support and scheduling. This guide
@@ -93,7 +93,7 @@
             <img src="images/automation-growth.png" alt="How AI Agents Help Startups Scale Faster" />
             <div class="blog-card-content">
               <div class="blog-card-category">Automation for Business Growth</div>
-              <h3 class="blog-card-title">How AI Agents Help Startups Scale Faster</h3>
+              <a href="posts/how-ai-agents-help-startups-scale-faster.html" class="blog-card-title">How AI Agents Help Startups Scale Faster</a>
               <p class="blog-card-excerpt">
                 Startups often struggle with limited manpower. Learn how AI agents take on
                 repetitive tasks, deliver rapid customer responses and provide insights that
@@ -107,7 +107,7 @@
             <img src="images/automation-growth.png" alt="Why Process Automation Is the Key to Lean Business Growth" />
             <div class="blog-card-content">
               <div class="blog-card-category">Automation for Business Growth</div>
-              <h3 class="blog-card-title">Why Process Automation Is the Key to Lean Business Growth</h3>
+              <a href="posts/why-process-automation-is-the-key-to-lean-business-growth.html" class="blog-card-title">Why Process Automation Is the Key to Lean Business Growth</a>
               <p class="blog-card-excerpt">
                 Lean growth is all about eliminating waste. This article explores how
                 automated processes reduce bottlenecks, cut costs and create a framework for
@@ -121,7 +121,7 @@
             <img src="images/automation-growth.png" alt="The ROI of AI: How Businesses Save Time and Money with Automation" />
             <div class="blog-card-content">
               <div class="blog-card-category">Automation for Business Growth</div>
-              <h3 class="blog-card-title">The ROI of AI: How Businesses Save Time and Money with Automation</h3>
+              <a href="posts/the-roi-of-ai-how-businesses-save-time-and-money-with-automation.html" class="blog-card-title">The ROI of AI: How Businesses Save Time and Money with Automation</a>
               <p class="blog-card-excerpt">
                 Understand the return on investment from AI initiatives. We'll show how
                 automation leads to measurable time savings and cost reductions across
@@ -135,7 +135,7 @@
             <img src="images/automation-growth.png" alt="From Startup to Scalable: The Role of Automation in Business Evolution" />
             <div class="blog-card-content">
               <div class="blog-card-category">Automation for Business Growth</div>
-              <h3 class="blog-card-title">From Startup to Scalable: The Role of Automation in Business Evolution</h3>
+              <a href="posts/from-startup-to-scalable-the-role-of-automation-in-business-evolution.html" class="blog-card-title">From Startup to Scalable: The Role of Automation in Business Evolution</a>
               <p class="blog-card-excerpt">
                 Every growing company reaches a point where manual processes no longer suffice.
                 Discover how automation paves the road from early‑stage chaos to scalable
@@ -149,7 +149,7 @@
             <img src="images/cost-efficiency.png" alt="5 Ways Automation Reduces Operational Costs" />
             <div class="blog-card-content">
               <div class="blog-card-category">Operational Efficiency &amp; Cost Reduction</div>
-              <h3 class="blog-card-title">5 Ways Automation Reduces Operational Costs</h3>
+              <a href="posts/5-ways-automation-reduces-operational-costs.html" class="blog-card-title">5 Ways Automation Reduces Operational Costs</a>
               <p class="blog-card-excerpt">
                 Learn five proven strategies for cutting overhead through automation – from
                 minimising human error to optimising resource allocation.
@@ -162,7 +162,7 @@
             <img src="images/cost-efficiency.png" alt="How to Use AI to Eliminate Repetitive Admin Work" />
             <div class="blog-card-content">
               <div class="blog-card-category">Operational Efficiency &amp; Cost Reduction</div>
-              <h3 class="blog-card-title">How to Use AI to Eliminate Repetitive Admin Work</h3>
+              <a href="posts/how-to-use-ai-to-eliminate-repetitive-admin-work.html" class="blog-card-title">How to Use AI to Eliminate Repetitive Admin Work</a>
               <p class="blog-card-excerpt">
                 Repetitive admin work slows your team down. Explore tools and tactics to
                 delegate these tasks to AI and reclaim productivity.
@@ -175,7 +175,7 @@
             <img src="images/cost-efficiency.png" alt="Automated Workflows That Improve Team Productivity" />
             <div class="blog-card-content">
               <div class="blog-card-category">Operational Efficiency &amp; Cost Reduction</div>
-              <h3 class="blog-card-title">Automated Workflows That Improve Team Productivity</h3>
+              <a href="posts/automated-workflows-that-improve-team-productivity.html" class="blog-card-title">Automated Workflows That Improve Team Productivity</a>
               <p class="blog-card-excerpt">
                 Streamlined workflows can boost morale and output. This post examines
                 automation patterns that unlock collaboration and efficiency.
@@ -188,7 +188,7 @@
             <img src="images/cost-efficiency.png" alt="The Hidden Costs of Manual Processes (And How to Fix Them)" />
             <div class="blog-card-content">
               <div class="blog-card-category">Operational Efficiency &amp; Cost Reduction</div>
-              <h3 class="blog-card-title">The Hidden Costs of Manual Processes (And How to Fix Them)</h3>
+              <a href="posts/the-hidden-costs-of-manual-processes-and-how-to-fix-them.html" class="blog-card-title">The Hidden Costs of Manual Processes (And How to Fix Them)</a>
               <p class="blog-card-excerpt">
                 Manual work doesn't just cost time; it erodes profits in unseen ways. Learn to
                 identify and fix these hidden costs through smart automation.
@@ -201,7 +201,7 @@
             <img src="images/cost-efficiency.png" alt="How AI Helps Businesses Do More with Less Staff" />
             <div class="blog-card-content">
               <div class="blog-card-category">Operational Efficiency &amp; Cost Reduction</div>
-              <h3 class="blog-card-title">How AI Helps Businesses Do More with Less Staff</h3>
+              <a href="posts/how-ai-helps-businesses-do-more-with-less-staff.html" class="blog-card-title">How AI Helps Businesses Do More with Less Staff</a>
               <p class="blog-card-excerpt">
                 AI can augment a lean workforce, ensuring your business scales without a
                 proportional increase in headcount.
@@ -214,7 +214,7 @@
             <img src="images/ai-education.png" alt="What Is an AI Agent? A Beginner-Friendly Breakdown" />
             <div class="blog-card-content">
               <div class="blog-card-category">AI Education &amp; Strategy</div>
-              <h3 class="blog-card-title">What Is an AI Agent? A Beginner-Friendly Breakdown</h3>
+              <a href="posts/what-is-an-ai-agent-a-beginner-friendly-breakdown.html" class="blog-card-title">What Is an AI Agent? A Beginner-Friendly Breakdown</a>
               <p class="blog-card-excerpt">
                 New to AI? This primer demystifies AI agents, explaining how they perceive,
                 decide and act to handle tasks on your behalf.
@@ -227,7 +227,7 @@
             <img src="images/ai-education.png" alt="RPA vs AI Agents: What's the Difference and When to Use Each?" />
             <div class="blog-card-content">
               <div class="blog-card-category">AI Education &amp; Strategy</div>
-              <h3 class="blog-card-title">RPA vs AI Agents: What's the Difference and When to Use Each?</h3>
+              <a href="posts/rpa-vs-ai-agents-whats-the-difference-and-when-to-use-each.html" class="blog-card-title">RPA vs AI Agents: What's the Difference and When to Use Each?</a>
               <p class="blog-card-excerpt">
                 Confused about RPA and AI agents? We contrast these technologies and guide you
                 on choosing the right tool for your challenge.
@@ -240,7 +240,7 @@
             <img src="images/ai-education.png" alt="How to Build an Automation Strategy for Your Business" />
             <div class="blog-card-content">
               <div class="blog-card-category">AI Education &amp; Strategy</div>
-              <h3 class="blog-card-title">How to Build an Automation Strategy for Your Business</h3>
+              <a href="posts/how-to-build-an-automation-strategy-for-your-business.html" class="blog-card-title">How to Build an Automation Strategy for Your Business</a>
               <p class="blog-card-excerpt">
                 Automation works best with a plan. This article walks you through setting
                 goals, selecting processes and measuring impact.
@@ -253,7 +253,7 @@
             <img src="images/ai-education.png" alt="AI in 2025: What Every Business Owner Should Be Preparing For" />
             <div class="blog-card-content">
               <div class="blog-card-category">AI Education &amp; Strategy</div>
-              <h3 class="blog-card-title">AI in 2025: What Every Business Owner Should Be Preparing For</h3>
+              <a href="posts/ai-in-2025-what-every-business-owner-should-be-preparing-for.html" class="blog-card-title">AI in 2025: What Every Business Owner Should Be Preparing For</a>
               <p class="blog-card-excerpt">
                 Look ahead to 2025 and beyond. Discover emerging trends and how to prepare
                 your business to thrive in an AI‑driven world.
@@ -266,7 +266,7 @@
             <img src="images/ai-education.png" alt="How to Choose the Right Automation Tools for Your Business" />
             <div class="blog-card-content">
               <div class="blog-card-category">AI Education &amp; Strategy</div>
-              <h3 class="blog-card-title">How to Choose the Right Automation Tools for Your Business</h3>
+              <a href="posts/how-to-choose-the-right-automation-tools-for-your-business.html" class="blog-card-title">How to Choose the Right Automation Tools for Your Business</a>
               <p class="blog-card-excerpt">
                 With countless automation tools available, selecting the right one can feel
                 overwhelming. We break down the criteria that matter most.
@@ -279,7 +279,7 @@
             <img src="images/industry-insights.png" alt="Automation for E-Commerce: Reduce Refunds and Boost Conversions" />
             <div class="blog-card-content">
               <div class="blog-card-category">Industry‑Specific Insights</div>
-              <h3 class="blog-card-title">Automation for E‑Commerce: Reduce Refunds and Boost Conversions</h3>
+              <a href="posts/automation-for-e-commerce-reduce-refunds-and-boost-conversions.html" class="blog-card-title">Automation for E‑Commerce: Reduce Refunds and Boost Conversions</a>
               <p class="blog-card-excerpt">
                 From personalised recommendations to smart inventory management, discover how
                 automation transforms e‑commerce experiences and profitability.
@@ -292,7 +292,7 @@
             <img src="images/industry-insights.png" alt="How AI Is Transforming Healthcare Admin & Patient Coordination" />
             <div class="blog-card-content">
               <div class="blog-card-category">Industry‑Specific Insights</div>
-              <h3 class="blog-card-title">How AI Is Transforming Healthcare Admin &amp; Patient Coordination</h3>
+              <a href="posts/how-ai-is-transforming-healthcare-admin-and-patient-coordination.html" class="blog-card-title">How AI Is Transforming Healthcare Admin &amp; Patient Coordination</a>
               <p class="blog-card-excerpt">
                 Explore real‑world examples of AI streamlining administrative tasks and
                 improving patient journeys across healthcare settings.
@@ -305,7 +305,7 @@
             <img src="images/industry-insights.png" alt="Automation in Real Estate: From Lead Capture to Property Scheduling" />
             <div class="blog-card-content">
               <div class="blog-card-category">Industry‑Specific Insights</div>
-              <h3 class="blog-card-title">Automation in Real Estate: From Lead Capture to Property Scheduling</h3>
+              <a href="posts/automation-in-real-estate-from-lead-capture-to-property-scheduling.html" class="blog-card-title">Automation in Real Estate: From Lead Capture to Property Scheduling</a>
               <p class="blog-card-excerpt">
                 Real estate agencies thrive on speed. Learn how automation accelerates lead
                 capture, follow‑up and property scheduling.
@@ -318,7 +318,7 @@
             <img src="images/industry-insights.png" alt="How Agencies Use AI to Deliver Results at Scale" />
             <div class="blog-card-content">
               <div class="blog-card-category">Industry‑Specific Insights</div>
-              <h3 class="blog-card-title">How Agencies Use AI to Deliver Results at Scale</h3>
+              <a href="posts/how-agencies-use-ai-to-deliver-results-at-scale.html" class="blog-card-title">How Agencies Use AI to Deliver Results at Scale</a>
               <p class="blog-card-excerpt">
                 Agencies manage multiple clients and campaigns. See how AI‑powered tools help
                 them produce consistent, scalable outcomes.
@@ -331,7 +331,7 @@
             <img src="images/industry-insights.png" alt="Logistics & Delivery: AI Use Cases That Save Time and Fuel" />
             <div class="blog-card-content">
               <div class="blog-card-category">Industry‑Specific Insights</div>
-              <h3 class="blog-card-title">Logistics &amp; Delivery: AI Use Cases That Save Time and Fuel</h3>
+              <a href="posts/logistics-and-delivery-ai-use-cases-that-save-time-and-fuel.html" class="blog-card-title">Logistics &amp; Delivery: AI Use Cases That Save Time and Fuel</a>
               <p class="blog-card-excerpt">
                 AI is revolutionising logistics. Find out how route optimisation and
                 predictive maintenance save time and energy.
@@ -344,7 +344,7 @@
             <img src="images/technology-tooling.png" alt="Best Tools to Automate Your Business in 2025" />
             <div class="blog-card-content">
               <div class="blog-card-category">Technology &amp; Tooling</div>
-              <h3 class="blog-card-title">Best Tools to Automate Your Business in 2025</h3>
+              <a href="posts/best-tools-to-automate-your-business-in-2025.html" class="blog-card-title">Best Tools to Automate Your Business in 2025</a>
               <p class="blog-card-excerpt">
                 Our curated list of the top automation platforms and software you should
                 consider for future‑proofing your operations.
@@ -357,7 +357,7 @@
             <img src="images/technology-tooling.png" alt="AI + Zapier: Building Smart Automations Without Code" />
             <div class="blog-card-content">
               <div class="blog-card-category">Technology &amp; Tooling</div>
-              <h3 class="blog-card-title">AI + Zapier: Building Smart Automations Without Code</h3>
+              <a href="posts/ai-zapier-building-smart-automations-without-code.html" class="blog-card-title">AI + Zapier: Building Smart Automations Without Code</a>
               <p class="blog-card-excerpt">
                 Learn how combining AI capabilities with no‑code platforms like Zapier
                 empowers anyone to build intelligent workflows.
@@ -370,7 +370,7 @@
             <img src="images/technology-tooling.png" alt="How to Integrate Slack, Google, and CRMs Using AI Agents" />
             <div class="blog-card-content">
               <div class="blog-card-category">Technology &amp; Tooling</div>
-              <h3 class="blog-card-title">How to Integrate Slack, Google, and CRMs Using AI Agents</h3>
+              <a href="posts/how-to-integrate-slack-google-and-crms-using-ai-agents.html" class="blog-card-title">How to Integrate Slack, Google, and CRMs Using AI Agents</a>
               <p class="blog-card-excerpt">
                 Integrations can be messy. This guide shows how AI agents unify your
                 communication tools and CRMs for seamless data flow.
@@ -383,7 +383,7 @@
             <img src="images/technology-tooling.png" alt="AI Dashboards: Why You Need One (And What It Should Track)" />
             <div class="blog-card-content">
               <div class="blog-card-category">Technology &amp; Tooling</div>
-              <h3 class="blog-card-title">AI Dashboards: Why You Need One (And What It Should Track)</h3>
+              <a href="posts/ai-dashboards-why-you-need-one-and-what-it-should-track.html" class="blog-card-title">AI Dashboards: Why You Need One (And What It Should Track)</a>
               <p class="blog-card-excerpt">
                 AI‑powered dashboards can unlock insights. Learn which metrics matter and how
                 to choose or build a dashboard that works for you.
@@ -396,7 +396,7 @@
             <img src="images/technology-tooling.png" alt="The Future of Business Intelligence: AI-Powered Decision Making" />
             <div class="blog-card-content">
               <div class="blog-card-category">Technology &amp; Tooling</div>
-              <h3 class="blog-card-title">The Future of Business Intelligence: AI‑Powered Decision Making</h3>
+              <a href="posts/the-future-of-business-intelligence-ai-powered-decision-making.html" class="blog-card-title">The Future of Business Intelligence: AI‑Powered Decision Making</a>
               <p class="blog-card-excerpt">
                 Business intelligence is evolving. Discover how AI transforms data into
                 real‑time decisions and strategic advantages.
@@ -409,7 +409,7 @@
             <img src="images/motivational.png" alt="Why We Started AIAGENTSAGE (And What We Learned About AI)" />
             <div class="blog-card-content">
               <div class="blog-card-category">Motivational &amp; Founder Insights</div>
-              <h3 class="blog-card-title">Why We Started AIAGENTSAGE (And What We Learned About AI)</h3>
+              <a href="posts/why-we-started-aiagentsage-and-what-we-learned-about-ai.html" class="blog-card-title">Why We Started AIAGENTSAGE (And What We Learned About AI)</a>
               <p class="blog-card-excerpt">
                 Our founder shares the journey behind AIAGENTSAGE and the lessons learned from
                 building AI‑driven solutions.
@@ -422,7 +422,7 @@
             <img src="images/motivational.png" alt="Lessons From Automating Our Own Business Operations" />
             <div class="blog-card-content">
               <div class="blog-card-category">Motivational &amp; Founder Insights</div>
-              <h3 class="blog-card-title">Lessons From Automating Our Own Business Operations</h3>
+              <a href="posts/lessons-from-automating-our-own-business-operations.html" class="blog-card-title">Lessons From Automating Our Own Business Operations</a>
               <p class="blog-card-excerpt">
                 We practice what we preach. In this candid post, we reveal the wins and
                 surprises from automating our internal processes.
@@ -435,7 +435,7 @@
             <img src="images/motivational.png" alt="The First 5 Processes Every Founder Should Automate" />
             <div class="blog-card-content">
               <div class="blog-card-category">Motivational &amp; Founder Insights</div>
-              <h3 class="blog-card-title">The First 5 Processes Every Founder Should Automate</h3>
+              <a href="posts/the-first-5-processes-every-founder-should-automate.html" class="blog-card-title">The First 5 Processes Every Founder Should Automate</a>
               <p class="blog-card-excerpt">
                 Not sure where to begin? Here are five immediate automation wins that founders
                 can implement to reclaim valuable time.
@@ -448,7 +448,7 @@
             <img src="images/motivational.png" alt="From Chaos to Clarity: How AI Brought Structure to Our Growth" />
             <div class="blog-card-content">
               <div class="blog-card-category">Motivational &amp; Founder Insights</div>
-              <h3 class="blog-card-title">From Chaos to Clarity: How AI Brought Structure to Our Growth</h3>
+              <a href="posts/from-chaos-to-clarity-how-ai-brought-structure-to-our-growth.html" class="blog-card-title">From Chaos to Clarity: How AI Brought Structure to Our Growth</a>
               <p class="blog-card-excerpt">
                 Growth often comes with chaos. Learn how AI brought order to our scaling
                 journey and how it can help you too.
@@ -461,7 +461,7 @@
             <img src="images/motivational.png" alt="How Automation Helped Us Reclaim 30+ Hours a Week" />
             <div class="blog-card-content">
               <div class="blog-card-category">Motivational &amp; Founder Insights</div>
-              <h3 class="blog-card-title">How Automation Helped Us Reclaim 30+ Hours a Week</h3>
+              <a href="posts/how-automation-helped-us-reclaim-30-plus-hours-a-week.html" class="blog-card-title">How Automation Helped Us Reclaim 30+ Hours a Week</a>
               <p class="blog-card-excerpt">
                 Time is your scarcest asset. Here's how we automated tasks to save more than
                 30 hours each week.

--- a/css/styles.css
+++ b/css/styles.css
@@ -402,6 +402,7 @@ a {
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   display: flex;
   flex-direction: column;
+  cursor: pointer;
 }
 
 .blog-card:hover {
@@ -428,14 +429,11 @@ a {
   margin-bottom: 0.5rem;
   color: var(--primary);
   line-height: 1.3;
-}
-
-.blog-card-title a {
-  color: inherit;
   transition: color 0.3s;
+  display: block;
 }
 
-.blog-card-title a:hover {
+.blog-card-title:hover {
   color: var(--accent);
 }
 
@@ -663,6 +661,7 @@ a {
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   display: flex;
   flex-direction: column;
+  cursor: pointer;
 }
 
 .blog-card:hover {
@@ -697,6 +696,12 @@ a {
   color: var(--primary);
   margin-bottom: 0.5rem;
   line-height: 1.3;
+  transition: color 0.3s ease;
+  display: block;
+}
+
+.blog-card-title:hover {
+  color: var(--accent);
 }
 
 .blog-card-excerpt {

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -57,4 +57,14 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  // Make entire blog cards clickable
+  document.querySelectorAll('.blog-card').forEach((card) => {
+    const link = card.querySelector('.blog-card-title');
+    if (link) {
+      card.addEventListener('click', () => {
+        window.location.href = link.getAttribute('href');
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Convert blog card titles from `<h3>` elements to anchor links pointing to the same URL as each card's "Read more" link.
- Add a click handler so that clicking anywhere on a blog card navigates to the linked post and apply hover/pointer styles for clarity.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f48b811883338b2e6aa06f961785