### PR TITLE
Set header call-to-action text to primary color

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -554,6 +554,7 @@ a {
 
 .main-nav .nav-cta {
   margin-left: 1rem;
+  color: var(--primary);
 }
 
 .nav-toggle {


### PR DESCRIPTION
## Summary
- make `.main-nav .nav-cta` text inherit the primary blue color for emphasis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892082abd2883339d7352fdf59fe224