### PR TITLE
Use responsive font size for business name

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -631,7 +631,7 @@ a {
 
 .business-name {
   font-family: 'Orbitron', sans-serif;
-  font-size: 3rem;
+  font-size: clamp(2rem, 8vw, 3rem);
   color: var(--accent);
   letter-spacing: 1px;
 }


### PR DESCRIPTION
## Summary
- replace fixed `font-size` in `.business-name` with responsive `clamp`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892082dd05c83339006c8aa526cd371