### PR TITLE
Expand responsive breakpoints and highlight nav toggle

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -560,12 +560,13 @@ a {
   display: none;
   background: none;
   border: none;
-  color: #cbd5e1;
+  color: var(--accent);
   font-size: 1.5rem;
   cursor: pointer;
+  z-index: 1001;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .nav-container {
     position: relative;
   }
@@ -650,7 +651,7 @@ a {
 }
 
 /* Responsive */
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .section {
     padding: 3rem 0;
   }
@@ -800,7 +801,7 @@ a {
   color: #00c853;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .blog-grid {
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     gap: 1.5rem;


### PR DESCRIPTION
## Summary
- expand mobile breakpoints from 768px to 1024px for navigation, layout sections, and blog grid
- style nav toggle with accent color and higher z-index so it remains visible on dark headers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892082baf70833397224170bbece390