### PR TITLE
chore: add example environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Required environment variables
+EMAIL_USER=your_email@example.com
+EMAIL_PASS=your_email_password
+
+# Optional environment variables
+PORT=3000
+


### PR DESCRIPTION
## Summary
- add .env.example with required EMAIL_USER and EMAIL_PASS variables
- include optional PORT variable

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920ab8ca408333ab72478755e1ca4a